### PR TITLE
Provide a hint to github that this is a Smalltalk project.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@ text  eol=crlf
 *.pac eol=crlf
 *.pax eol=crlf
 *.stb binary
+*.cls linguist-language=Smalltalk


### PR DESCRIPTION
Tells github-linguist that the .cls files are Smalltalk source files and not Apex source files.